### PR TITLE
fix: wasm-tools workload installation in GitHub Actions workflows.

### DIFF
--- a/.github/workflows/azure-static-web-apps-brave-stone-0645cc000.yml
+++ b/.github/workflows/azure-static-web-apps-brave-stone-0645cc000.yml
@@ -23,9 +23,7 @@ jobs:
         with:
           dotnet-version: '8.0.x'
       - name: Install wasm-tools
-        run: |
-            dotnet workload install wasm-tools-net8 --verbosity minimal || \
-            dotnet workload install wasm-tools --verbosity minimal
+        run: dotnet workload install wasm-tools --verbosity minimal
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/deploy-to-ghpages.yml
+++ b/.github/workflows/deploy-to-ghpages.yml
@@ -24,9 +24,7 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
     - name: ⚙️ Install wasm-tools
-      run: |
-          dotnet workload install wasm-tools-net8 --verbosity minimal || \
-          dotnet workload install wasm-tools --verbosity minimal
+      run: dotnet workload install wasm-tools --verbosity minimal
     - name: 🚚 Restore
       run: dotnet restore "${{ env.WORKING_DIRECTORY }}"
     - name: 🛠️ Build


### PR DESCRIPTION
- Replace the invalid wasm-tools-net8 workload installation with wasm-tools
- This fixes the failing "Install wasm-tools" step under .NET 8.x
- refs: #102