### PR TITLE
fix: Oryx build failure by skipping build step and using manual dotnet publish.

### DIFF
--- a/.github/workflows/azure-static-web-apps-brave-stone-0645cc000.yml
+++ b/.github/workflows/azure-static-web-apps-brave-stone-0645cc000.yml
@@ -26,6 +26,9 @@ jobs:
         run: |
             dotnet workload install wasm-tools-net8 --verbosity minimal || \
             dotnet workload install wasm-tools --verbosity minimal
+      - name: Publish Blazor App
+        # see: https://github.com/Azure/static-web-apps/issues/1692#issuecomment-3568257932
+        run: dotnet publish ./TryAzureStaticBlazorApp --configuration Release --output ./publish
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
@@ -37,11 +40,9 @@ jobs:
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "/TryAzureStaticBlazorApp" # App source code path
           api_location: "Api" # Api source code path - optional
-          # see: https://github.com/Azure/static-web-apps/issues/1692#issuecomment-3568257932
           output_location: "publish/wwwroot" # Built app content directory - optional
           skip_api_build: true
           skip_app_build: true
-          app_build_command: "dotnet publish --configuration Release --output publish"
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:

--- a/.github/workflows/azure-static-web-apps-brave-stone-0645cc000.yml
+++ b/.github/workflows/azure-static-web-apps-brave-stone-0645cc000.yml
@@ -38,9 +38,9 @@ jobs:
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/TryAzureStaticBlazorApp" # App source code path
+          app_location: "/publish/wwwroot" # App source code path
           api_location: "Api" # Api source code path - optional
-          output_location: "publish/wwwroot" # Built app content directory - optional
+          output_location: "." # Built app content directory - optional
           skip_api_build: true
           skip_app_build: true
           ###### End of Repository/Build Configurations ######

--- a/.github/workflows/azure-static-web-apps-brave-stone-0645cc000.yml
+++ b/.github/workflows/azure-static-web-apps-brave-stone-0645cc000.yml
@@ -37,7 +37,11 @@ jobs:
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "/TryAzureStaticBlazorApp" # App source code path
           api_location: "Api" # Api source code path - optional
-          output_location: "wwwroot" # Built app content directory - optional
+          # see: https://github.com/Azure/static-web-apps/issues/1692#issuecomment-3568257932
+          output_location: "publish/wwwroot" # Built app content directory - optional
+          skip_api_build: true
+          skip_app_build: true
+          app_build_command: "dotnet publish --configuration Release --output publish"
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:


### PR DESCRIPTION
### Description
Fixes the "SDK not found" error from Oryx during Azure Static Web Apps deployment by skipping the automatic build process and manually publishing the Blazor WASM application using the pre-installed .NET SDK.

### Changes
- Add a separate "Publish Blazor App" step to manually run dotnet publish before deployment
- Skip Oryx app and API builds with skip_app_build and skip_api_build flags in the deploy action
- Update app_location to point to the published wwwroot directory where index.html is located
- Set output_location to "." since the app artifacts are already in the app_location directory
- Remove reliance on app_build_command which is ignored when skip_app_build is true